### PR TITLE
Adds a default flavor dimension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ android {
     compileSdkVersion 26
     buildToolsVersion "26.0.1"
     publishNonDefault true
+    
+    flavorDimensions "default"
 
     defaultConfig {
         resValue "string", "content_authority", applicationId + '.provider'


### PR DESCRIPTION
This is necessary for gradle > 3.0

More 👉 https://stackoverflow.com/questions/44105127/android-studio-3-0-flavor-dimension-issue