### PR TITLE
Allow transforming or rejecting coordinates with a special transform

### DIFF
--- a/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
+++ b/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
@@ -572,4 +572,19 @@ public class BackgroundGeolocationFacade {
         }
         return true;
     }
+
+    /**
+     * Sets a transform for each coordinate about to be committed (sent or saved for later sync).
+     * You can use this for modifying the coordinates in any way.
+     *
+     * If the transform returns <code>null</code>, it will prevent the location from being committed.
+     * @param transform - the transform listener
+     */
+    public static void setLocationTransform(LocationService.ILocationTransform transform) {
+        LocationService.setLocationTransform(transform);
+    }
+
+    public static LocationService.ILocationTransform getLocationTransform() {
+        return LocationService.getLocationTransform();
+    }
 }


### PR DESCRIPTION
## Motivation

A concern was raised by users, where they do not want coordinates to be transmitted from their home address.  
It's a common privacy issue.

Our idea was to let them set a "reverse fence" around their home. Where all coordinates transmitted within a certain radius - will be offset by around 1km.

## Implementation

In order to achieve the desired result, we have to intervene even when the app is in the background, or as a service. At this stage some user mode code like React Native's JS will not have been executed yet.

I came up with a "transform", where all coordinates pass through. You can modify them or return a new one. Or you can reject them by returning null.

Due to the fact that the Facade is in most cases not owned by the developer - for example in RN situation where it is owned by the RCT module, and that module is also owned by RN, we have to access the modules statically.
So static setters have been written for the Facade.

As I believe in separation of concerns, I left the issue of "how to filter", or in RN's situation "how to share settings with the transformer" to the user, to handle with a separate technique/library.

## Usage

When the `Application` is initialized (which also happens before services gets started in the background), write some code like this:

```
BackgroundGeolocationFacade.setLocationTransform(new ILocationTransform() {
            @Nullable
            @Override
            public BackgroundLocation transformLocationBeforeCommit(@NonNull Context context, @NonNull BackgroundLocation location) {
                // `context` is available too if there's a need to use a value from preferences etc.
                location.setLatitude(location.getLatitude() + 0.018);
                return location;
            }
        }
```

Note: The equivalent iOS PR is here: https://github.com/mauron85/background-geolocation-ios/pull/3