### PR TITLE
Added a feature to disable notifications on Android

### DIFF
--- a/src/main/java/com/marianhello/bgloc/Config.java
+++ b/src/main/java/com/marianhello/bgloc/Config.java
@@ -12,6 +12,7 @@ package com.marianhello.bgloc;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.Nullable;
 
 import com.marianhello.bgloc.data.AbstractLocationTemplate;
 import com.marianhello.bgloc.data.LocationTemplate;
@@ -54,6 +55,7 @@ public class Config implements Parcelable
     private Boolean stopOnTerminate;
     private Boolean startOnBoot;
     private Boolean startForeground;
+    private Boolean notificationsEnabled;
     private Boolean stopOnStillActivity;
     private String url;
     private String syncUrl;
@@ -83,6 +85,7 @@ public class Config implements Parcelable
         this.stopOnTerminate = config.stopOnTerminate;
         this.startOnBoot = config.startOnBoot;
         this.startForeground = config.startForeground;
+        this.notificationsEnabled = config.notificationsEnabled;
         this.stopOnStillActivity = config.stopOnStillActivity;
         this.url = config.url;
         this.syncUrl = config.syncUrl;
@@ -107,6 +110,7 @@ public class Config implements Parcelable
         setStopOnTerminate((Boolean) in.readValue(null));
         setStartOnBoot((Boolean) in.readValue(null));
         setStartForeground((Boolean) in.readValue(null));
+        setNotificationsEnabled((Boolean) in.readValue(null));
         setLocationProvider(in.readInt());
         setInterval(in.readInt());
         setFastestInterval(in.readInt());
@@ -139,6 +143,7 @@ public class Config implements Parcelable
         config.stopOnTerminate = true;
         config.startOnBoot = false;
         config.startForeground = true;
+        config.notificationsEnabled = true;
         config.stopOnStillActivity = true;
         config.url = "";
         config.syncUrl = "";
@@ -168,6 +173,7 @@ public class Config implements Parcelable
         out.writeValue(getStopOnTerminate());
         out.writeValue(getStartOnBoot());
         out.writeValue(getStartForeground());
+        out.writeValue(getNotificationsEnabled());
         out.writeInt(getLocationProvider());
         out.writeInt(getInterval());
         out.writeInt(getFastestInterval());
@@ -340,6 +346,19 @@ public class Config implements Parcelable
 
     public void setStartForeground(Boolean startForeground) {
         this.startForeground = startForeground;
+    }
+
+    public boolean hasNotificationsEnabled() {
+        return notificationsEnabled != null;
+    }
+
+    @Nullable
+    public Boolean getNotificationsEnabled() {
+        return notificationsEnabled;
+    }
+
+    public void setNotificationsEnabled(@Nullable Boolean notificationsEnabled) {
+        this.notificationsEnabled = notificationsEnabled;
     }
 
     public boolean hasLocationProvider() {
@@ -515,6 +534,7 @@ public class Config implements Parcelable
                 .append(" stopOnStillActivity=").append(getStopOnStillActivity())
                 .append(" startOnBoot=").append(getStartOnBoot())
                 .append(" startForeground=").append(getStartForeground())
+                .append(" notificationsEnabled=").append(getNotificationsEnabled())
                 .append(" locationProvider=").append(getLocationProvider())
                 .append(" nTitle=").append(getNotificationTitle())
                 .append(" nText=").append(getNotificationText())
@@ -594,6 +614,9 @@ public class Config implements Parcelable
         }
         if (config2.hasStartForeground()) {
             merger.setStartForeground(config2.getStartForeground());
+        }
+        if (config2.hasNotificationsEnabled()) {
+            merger.setNotificationsEnabled(config2.getNotificationsEnabled());
         }
         if (config2.hasStopOnStillActivity()) {
             merger.setStopOnStillActivity(config2.getStopOnStillActivity());

--- a/src/main/java/com/marianhello/bgloc/data/sqlite/SQLiteConfigurationContract.java
+++ b/src/main/java/com/marianhello/bgloc/data/sqlite/SQLiteConfigurationContract.java
@@ -23,6 +23,7 @@ public final class SQLiteConfigurationContract {
         public static final String COLUMN_NAME_STOP_TERMINATE = "stop_terminate";
         public static final String COLUMN_NAME_START_BOOT = "start_boot";
         public static final String COLUMN_NAME_START_FOREGROUND = "start_foreground";
+        public static final String COLUMN_NAME_NOTIFICATIONS_ENABLED = "notifications_enabled";
         public static final String COLUMN_NAME_STOP_ON_STILL = "stop_still";
         public static final String COLUMN_NAME_LOCATION_PROVIDER = "service_provider";
         public static final String COLUMN_NAME_INTERVAL = "interval";

--- a/src/main/java/com/marianhello/bgloc/data/sqlite/SQLiteConfigurationDAO.java
+++ b/src/main/java/com/marianhello/bgloc/data/sqlite/SQLiteConfigurationDAO.java
@@ -46,6 +46,7 @@ public class SQLiteConfigurationDAO implements ConfigurationDAO {
       ConfigurationEntry.COLUMN_NAME_STOP_ON_STILL,
       ConfigurationEntry.COLUMN_NAME_START_BOOT,
       ConfigurationEntry.COLUMN_NAME_START_FOREGROUND,
+      ConfigurationEntry.COLUMN_NAME_NOTIFICATIONS_ENABLED,
       ConfigurationEntry.COLUMN_NAME_LOCATION_PROVIDER,
       ConfigurationEntry.COLUMN_NAME_INTERVAL,
       ConfigurationEntry.COLUMN_NAME_FASTEST_INTERVAL,
@@ -111,6 +112,7 @@ public class SQLiteConfigurationDAO implements ConfigurationDAO {
     config.setStopOnStillActivity( (c.getInt(c.getColumnIndex(ConfigurationEntry.COLUMN_NAME_STOP_ON_STILL)) == 1) ? true : false );
     config.setStartOnBoot( (c.getInt(c.getColumnIndex(ConfigurationEntry.COLUMN_NAME_START_BOOT)) == 1) ? true : false );
     config.setStartForeground( (c.getInt(c.getColumnIndex(ConfigurationEntry.COLUMN_NAME_START_FOREGROUND)) == 1) ? true : false );
+    config.setNotificationsEnabled( (c.getInt(c.getColumnIndex(ConfigurationEntry.COLUMN_NAME_NOTIFICATIONS_ENABLED)) == 1) ? true : false );
     config.setLocationProvider(c.getInt(c.getColumnIndex(ConfigurationEntry.COLUMN_NAME_LOCATION_PROVIDER)));
     config.setInterval(c.getInt(c.getColumnIndex(ConfigurationEntry.COLUMN_NAME_INTERVAL)));
     config.setFastestInterval(c.getInt(c.getColumnIndex(ConfigurationEntry.COLUMN_NAME_FASTEST_INTERVAL)));
@@ -141,6 +143,7 @@ public class SQLiteConfigurationDAO implements ConfigurationDAO {
     values.put(ConfigurationEntry.COLUMN_NAME_STOP_ON_STILL, (config.getStopOnStillActivity() == true) ? 1 : 0);
     values.put(ConfigurationEntry.COLUMN_NAME_START_BOOT, (config.getStartOnBoot() == true) ? 1 : 0);
     values.put(ConfigurationEntry.COLUMN_NAME_START_FOREGROUND, (config.getStartForeground() == true) ? 1 : 0);
+    values.put(ConfigurationEntry.COLUMN_NAME_NOTIFICATIONS_ENABLED, (config.getNotificationsEnabled() == true) ? 1 : 0);
     values.put(ConfigurationEntry.COLUMN_NAME_LOCATION_PROVIDER, config.getLocationProvider());
     values.put(ConfigurationEntry.COLUMN_NAME_INTERVAL, config.getInterval());
     values.put(ConfigurationEntry.COLUMN_NAME_FASTEST_INTERVAL, config.getFastestInterval());

--- a/src/main/java/com/marianhello/bgloc/data/sqlite/SQLiteOpenHelper.java
+++ b/src/main/java/com/marianhello/bgloc/data/sqlite/SQLiteOpenHelper.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 public class SQLiteOpenHelper extends android.database.sqlite.SQLiteOpenHelper {
     private static final String TAG = SQLiteOpenHelper.class.getName();
     public static final String SQLITE_DATABASE_NAME = "cordova_bg_geolocation.db";
-    public static final int DATABASE_VERSION = 14;
+    public static final int DATABASE_VERSION = 15;
 
     private static final String TEXT_TYPE = " TEXT";
     private static final String INTEGER_TYPE = " INTEGER";
@@ -60,6 +60,7 @@ public class SQLiteOpenHelper extends android.database.sqlite.SQLiteOpenHelper {
         ConfigurationEntry.COLUMN_NAME_STOP_ON_STILL + INTEGER_TYPE + COMMA_SEP +
         ConfigurationEntry.COLUMN_NAME_START_BOOT + INTEGER_TYPE + COMMA_SEP +
         ConfigurationEntry.COLUMN_NAME_START_FOREGROUND + INTEGER_TYPE + COMMA_SEP +
+        ConfigurationEntry.COLUMN_NAME_NOTIFICATIONS_ENABLED + INTEGER_TYPE + COMMA_SEP +
         ConfigurationEntry.COLUMN_NAME_LOCATION_PROVIDER + TEXT_TYPE + COMMA_SEP +
         ConfigurationEntry.COLUMN_NAME_INTERVAL + INTEGER_TYPE + COMMA_SEP +
         ConfigurationEntry.COLUMN_NAME_FASTEST_INTERVAL + INTEGER_TYPE + COMMA_SEP +
@@ -165,6 +166,9 @@ public class SQLiteOpenHelper extends android.database.sqlite.SQLiteOpenHelper {
             case 13:
                 alterSql.add("ALTER TABLE " + LocationEntry.TABLE_NAME +
                         " ADD COLUMN " + LocationEntry.COLUMN_NAME_MOCK_FLAGS + INTEGER_TYPE);
+            case 14:
+                alterSql.add("ALTER TABLE " + ConfigurationEntry.TABLE_NAME +
+                        " ADD COLUMN " + ConfigurationEntry.COLUMN_NAME_NOTIFICATIONS_ENABLED + INTEGER_TYPE);
 
                 break; // DO NOT FORGET TO MOVE DOWN BREAK ON DB UPGRADE!!!
             default:

--- a/src/oreo/java/com/marianhello/bgloc/sync/SyncAdapter.java
+++ b/src/oreo/java/com/marianhello/bgloc/sync/SyncAdapter.java
@@ -39,6 +39,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements Uploadin
     private ConfigurationDAO configDAO;
     private NotificationManager notificationManager;
     private BatchManager batchManager;
+    private boolean notificationsEnabled = true;
 
     private org.slf4j.Logger logger;
 
@@ -99,6 +100,9 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements Uploadin
             return;
         }
 
+        //noinspection ConstantConditions
+        notificationsEnabled = !config.hasNotificationsEnabled() || config.getNotificationsEnabled();
+
         Long batchStartMillis = System.currentTimeMillis();
         boolean isForced = extras.getBoolean(ContentResolver.SYNC_EXTRAS_MANUAL);
         int syncThreshold = isForced ? 0 : config.getSyncThreshold();
@@ -137,41 +141,52 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements Uploadin
     }
 
     private boolean uploadLocations(File file, String url, HashMap httpHeaders) {
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext(), NotificationHelper.SYNC_CHANNEL_ID);
-        builder.setOngoing(true);
-        builder.setContentTitle("Syncing locations");
-        builder.setContentText("Sync in progress");
-        builder.setSmallIcon(android.R.drawable.ic_dialog_info);
-        notificationManager.notify(NOTIFICATION_ID, builder.build());
+        NotificationCompat.Builder builder = null;
+
+        if (notificationsEnabled) {
+            builder = new NotificationCompat.Builder(getContext(), NotificationHelper.SYNC_CHANNEL_ID);
+            builder.setOngoing(true);
+            builder.setContentTitle("Syncing locations");
+            builder.setContentText("Sync in progress");
+            builder.setSmallIcon(android.R.drawable.ic_dialog_info);
+            notificationManager.notify(NOTIFICATION_ID, builder.build());
+        }
 
         try {
             int responseCode = HttpPostService.postFile(url, file, httpHeaders, this);
-            if (responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_CREATED) {
-                builder.setContentText("Sync completed");
-            } else {
-                builder.setContentText("Sync failed due server error");
+
+            if (builder != null) {
+                if (responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_CREATED) {
+                    builder.setContentText("Sync completed");
+                } else {
+                    builder.setContentText("Sync failed due server error");
+                }
             }
 
             return responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_CREATED;
         } catch (IOException e) {
             logger.warn("Error uploading locations: {}", e.getMessage());
-            builder.setContentText("Sync failed: " + e.getMessage());
+
+            if (builder != null)
+                builder.setContentText("Sync failed: " + e.getMessage());
         } finally {
             logger.info("Syncing endAt: {}", System.currentTimeMillis());
 
-            builder.setOngoing(false);
-            builder.setProgress(0, 0, false);
-            builder.setAutoCancel(true);
-            notificationManager.notify(NOTIFICATION_ID, builder.build());
-            
-            Handler h = new Handler(Looper.getMainLooper());
-            long delayInMilliseconds = 5000;
-            h.postDelayed(new Runnable() {
-                public void run() {
-                    logger.info("Notification cancelledAt: {}", System.currentTimeMillis());
-                    notificationManager.cancel(NOTIFICATION_ID);
-                }
-            }, delayInMilliseconds);
+            if (builder != null) {
+                builder.setOngoing(false);
+                builder.setProgress(0, 0, false);
+                builder.setAutoCancel(true);
+                notificationManager.notify(NOTIFICATION_ID, builder.build());
+
+                Handler h = new Handler(Looper.getMainLooper());
+                long delayInMilliseconds = 5000;
+                h.postDelayed(new Runnable() {
+                    public void run() {
+                        logger.info("Notification cancelledAt: {}", System.currentTimeMillis());
+                        notificationManager.cancel(NOTIFICATION_ID);
+                    }
+                }, delayInMilliseconds);
+            }
         }
 
         return false;
@@ -179,12 +194,15 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements Uploadin
 
     public void uploadListener(int progress) {
         logger.debug("Syncing progress: {} updatedAt: {}", progress, System.currentTimeMillis());
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext(), NotificationHelper.SYNC_CHANNEL_ID);
-        builder.setOngoing(true);
-        builder.setContentTitle("Syncing locations");
-        builder.setContentText("Sync in progress");
-        builder.setSmallIcon(android.R.drawable.ic_dialog_info);
-        builder.setProgress(100, progress, false);
-        notificationManager.notify(NOTIFICATION_ID, builder.build());
+
+        if (notificationsEnabled) {
+            NotificationCompat.Builder builder = new NotificationCompat.Builder(getContext(), NotificationHelper.SYNC_CHANNEL_ID);
+            builder.setOngoing(true);
+            builder.setContentTitle("Syncing locations");
+            builder.setContentText("Sync in progress");
+            builder.setSmallIcon(android.R.drawable.ic_dialog_info);
+            builder.setProgress(100, progress, false);
+            notificationManager.notify(NOTIFICATION_ID, builder.build());
+        }
     }
 }


### PR DESCRIPTION
Not everyone wants the library to force those notifications on them. There are other ways to convey to the user that the app is tracking in the background.

I have kept the original default where notifications are enabled, and it's an opt-out feature.
Set `notificationsEnabled: false` to disable local notifications.

Also closes:
https://github.com/mauron85/react-native-background-geolocation/issues/242