### PR TITLE
fix locationService treating success as errors

### DIFF
--- a/src/main/java/com/marianhello/bgloc/LocationService.java
+++ b/src/main/java/com/marianhello/bgloc/LocationService.java
@@ -629,9 +629,11 @@ public class LocationService extends Service implements ProviderDelegate {
                 if (mListener != null)
                     mListener.onRequestedAbortUpdates();
             }
-
+            
             // All 2xx statuses are okay
-            if (responseCode >= 200 && responseCode < 300) {
+            boolean isStatusOkay = responseCode >= 200 && responseCode < 300;
+            
+            if (!isStatusOkay) {
                 logger.warn("Server error while posting locations responseCode: {}", responseCode);
                 return false;
             }


### PR DESCRIPTION
Hi, 
I'm using cordova-plugin-background-geolocation and getting a warning after location post:

![pidcat](https://user-images.githubusercontent.com/400244/44930764-c08ae480-ad35-11e8-9ab4-3951186e768f.png)

Is the message and return following this comparison right?
https://github.com/mauron85/background-geolocation-android/blob/a9eb831211f11ed56745ae2c005e410e7a337d68/src/main/java/com/marianhello/bgloc/LocationService.java#L634

If the status code is 200 and, as stated, it's correct. Should'nt it return true, then the location would be deleted? Also, shouldn't the log message be positive? 

The location is being saved as pending location even though the post worked (200/): 
https://github.com/mauron85/background-geolocation-android/blob/a9eb831211f11ed56745ae2c005e410e7a337d68/src/main/java/com/marianhello/bgloc/LocationService.java#L580


fix #12