### PR TITLE
Companion PR to #14

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,10 @@ android {
         resValue "string", "content_authority", applicationId + '.provider'
         resValue "string", "account_type", applicationId
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        minSdkVersion 15
+        minSdkVersion 16
         versionCode 1
         versionName "1.0"
+        manifestPlaceholders = ["supportLibVersion": supportLibVersion]
     }
 
     sourceSets {

--- a/src/androidTest/AndroidManifest.xml
+++ b/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.marianhello.backgroundgeolocation">
+
+    <application>
+        <meta-data
+            android:name="android.support.VERSION"
+            android:value="${supportLibVersion}"
+            tools:replace="android:value" />
+    </application>
+</manifest>


### PR DESCRIPTION
Bumps the `minSdkVersion` to 16 and introduces an `AndroidManifest` within the
`androidTest` scope to permit consumer apps to override the support library version meta-data
tag.

see #14