### PR TITLE
Make sure mService exists when we call start or stop

### DIFF
--- a/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
+++ b/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
@@ -410,13 +410,17 @@ public class BackgroundGeolocationFacade {
 
     public void switchMode(final int mode) {
         synchronized (mLock) {
-            mService.executeProviderCommand(LocationProvider.CMD_SWITCH_MODE, mode);
+            if (mService != null) {
+                mService.executeProviderCommand(LocationProvider.CMD_SWITCH_MODE, mode);
+            }
         }
     }
 
     public void sendCommand(final int commandId) {
-        synchronized (mLock) {
-            mService.executeProviderCommand(commandId, 0);
+        synchronized (mLock) { 
+            if (mService != null) {
+                mService.executeProviderCommand(commandId, 0);
+            }
         }
     }
 

--- a/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
+++ b/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
@@ -417,7 +417,7 @@ public class BackgroundGeolocationFacade {
     }
 
     public void sendCommand(final int commandId) {
-        synchronized (mLock) { 
+        synchronized (mLock) {
             if (mService != null) {
                 mService.executeProviderCommand(commandId, 0);
             }

--- a/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
+++ b/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
@@ -519,14 +519,18 @@ public class BackgroundGeolocationFacade {
     private void startBackgroundService() {
         logger.info("Attempt to start bg service");
         synchronized (mLock) {
-            mService.start();
+            if (mService != null) {
+                mService.start();
+            }
         }
     }
 
     private void stopBackgroundService() {
         logger.info("Attempt to stop bg service");
         synchronized (mLock) {
-            mService.stop();
+            if (mService != null) {
+                mService.stop();
+            }
         }
     }
 


### PR DESCRIPTION
This handles the crash where mService has been killed or not initialized at all and the stop() method is called on a null value.

Examples:
```
Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'void com.marianhello.bgloc.LocationService.start()' on a null object reference
com.marianhello.bgloc.BackgroundGeolocationFacade.startBackgroundService
```

```
Unable to destroy activity {com.xxx.yyy/com.xxx.yyy.MainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.marianhello.bgloc.LocationService.stop()' on a null object reference
android.app.ActivityThread.performDestroyActivity
```