### PR TITLE
Sent an event when the http request is unauthorized

### DIFF
--- a/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
+++ b/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
@@ -208,6 +208,16 @@ public class BackgroundGeolocationFacade {
 
                     return;
                 }
+
+                case LocationService.MSG_ON_HTTP_AUTHORIZATION: {
+                    logger.debug("Received MSG_ON_HTTP_AUTHORIZATION");
+
+                    if (mDelegate != null) {
+                        mDelegate.onHttpAuthorization();
+                    } 
+
+                    return;
+                }
             }
         }
     };

--- a/src/main/java/com/marianhello/bgloc/LocationService.java
+++ b/src/main/java/com/marianhello/bgloc/LocationService.java
@@ -94,6 +94,8 @@ public class LocationService extends Service implements ProviderDelegate {
 
     public static final int MSG_ON_ABORT_REQUESTED = 106;
 
+    public static final int MSG_ON_HTTP_AUTHORIZATION = 107;
+
     public static final int SERVICE_STOPPED = 0;
     public static final int SERVICE_STARTED = 1;
 
@@ -195,6 +197,11 @@ public class LocationService extends Service implements ProviderDelegate {
             @Override
             public void onRequestedAbortUpdates() {
                 handleRequestedAbortUpdates();
+            }
+
+            @Override
+            public void onHttpAuthorizationUpdates() {
+                handleHttpAuthorizationUpdates();
             }
         });
         mSyncAccount = AccountHelper.CreateSyncAccount(this, SyncService.ACCOUNT_NAME,
@@ -630,6 +637,11 @@ public class LocationService extends Service implements ProviderDelegate {
                     mListener.onRequestedAbortUpdates();
             }
 
+            if (responseCode == 401) {
+                if (mListener != null)
+                    mListener.onHttpAuthorizationUpdates();
+            }
+
             // All 2xx statuses are okay
             boolean isStatusOkay = responseCode >= 200 && responseCode < 300;
 
@@ -645,6 +657,12 @@ public class LocationService extends Service implements ProviderDelegate {
     public void handleRequestedAbortUpdates() {
         Bundle bundle = new Bundle();
         bundle.putInt("action", MSG_ON_ABORT_REQUESTED);
+        broadcastMessage(bundle);
+    }
+
+    public void handleHttpAuthorizationUpdates() {
+        Bundle bundle = new Bundle();
+        bundle.putInt("action", MSG_ON_HTTP_AUTHORIZATION);
         broadcastMessage(bundle);
     }
 
@@ -705,5 +723,7 @@ public class LocationService extends Service implements ProviderDelegate {
     public interface PostLocationTaskListener
     {
         void onRequestedAbortUpdates();
+
+        void onHttpAuthorizationUpdates();
     }
 }

--- a/src/main/java/com/marianhello/bgloc/PluginDelegate.java
+++ b/src/main/java/com/marianhello/bgloc/PluginDelegate.java
@@ -14,5 +14,6 @@ public interface PluginDelegate {
     void onActitivyChanged(BackgroundActivity activity);
     void onServiceStatusChanged(int status);
     void onAbortRequested();
+    void onHttpAuthorization();
     void onError(PluginException error);
 }

--- a/src/oreo/java/com/marianhello/bgloc/sync/SyncAdapter.java
+++ b/src/oreo/java/com/marianhello/bgloc/sync/SyncAdapter.java
@@ -170,6 +170,12 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements Uploadin
                 broadcastMessage(bundle);
             }
 
+            if (responseCode == 401) {
+                Bundle bundle = new Bundle();
+                bundle.putInt("action", LocationService.MSG_ON_HTTP_AUTHORIZATION);
+                broadcastMessage(bundle);
+            }
+
             if (builder != null) {
                 if (isStatusOkay) {
                     builder.setContentText("Sync completed");

--- a/src/preoreo/java/com/marianhello/bgloc/sync/SyncAdapter.java
+++ b/src/preoreo/java/com/marianhello/bgloc/sync/SyncAdapter.java
@@ -171,6 +171,12 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements Uploadin
                 broadcastMessage(bundle);
             }
 
+            if (responseCode == 401) {
+                Bundle bundle = new Bundle();
+                bundle.putInt("action", LocationService.MSG_ON_HTTP_AUTHORIZATION);
+                broadcastMessage(bundle);
+            }
+
             if (builder != null) {
                 if (isStatusOkay) {
                     builder.setContentText("Sync completed");


### PR DESCRIPTION
related to [this](https://github.com/mauron85/react-native-background-geolocation/issues/307).

Library clients will be able to listen for 401 Unauthorized status codes received from http server.