### PR TITLE
Make sure ToneGenerator is only initialized when in debug mode

### DIFF
--- a/src/androidTest/java/com/marianhello/bgloc/provider/MockLocationProvider.java
+++ b/src/androidTest/java/com/marianhello/bgloc/provider/MockLocationProvider.java
@@ -16,6 +16,9 @@ public class MockLocationProvider extends AbstractLocationProvider {
     }
 
     @Override
+    public void onCreate() {}
+
+    @Override
     public void onStart() {
         mIsStarted = true;
         Iterator<Location> it = mMockLocations.iterator();

--- a/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
+++ b/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
@@ -48,11 +48,6 @@ public abstract class AbstractLocationProvider implements LocationProvider {
     }
 
     @Override
-    public void onCreate() {
-        toneGenerator = new android.media.ToneGenerator(AudioManager.STREAM_NOTIFICATION, 100);
-    }
-
-    @Override
     public void onDestroy() {
         toneGenerator.release();
         toneGenerator = null;
@@ -163,10 +158,18 @@ public abstract class AbstractLocationProvider implements LocationProvider {
      * @param name toneGenerator
      */
     protected void playDebugTone (int name) {
-        if (toneGenerator == null || !mConfig.isDebugging()) return;
+        if (!mConfig.isDebugging()) return;
 
-        int duration = 1000;
+        try {
+            if (toneGenerator == null) {
+                toneGenerator = new android.media.ToneGenerator(AudioManager.STREAM_NOTIFICATION, 100);
+            }
 
-        toneGenerator.startTone(name, duration);
+            int duration = 1000;
+
+            toneGenerator.startTone(name, duration);
+        } catch(RuntimeException e) {
+            logger.error("Failed to create android.media.ToneGenerator", e);
+        }
     }
 }

--- a/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
+++ b/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
@@ -49,8 +49,10 @@ public abstract class AbstractLocationProvider implements LocationProvider {
 
     @Override
     public void onDestroy() {
-        toneGenerator.release();
-        toneGenerator = null;
+        if (toneGenerator != null) {
+            toneGenerator.release();
+            toneGenerator = null;
+        }
     }
 
     @Override

--- a/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
+++ b/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
@@ -48,14 +48,11 @@ public abstract class AbstractLocationProvider implements LocationProvider {
     }
 
     @Override
-    public void onCreate() {
-        toneGenerator = new android.media.ToneGenerator(AudioManager.STREAM_NOTIFICATION, 100);
-    }
-
-    @Override
     public void onDestroy() {
-        toneGenerator.release();
-        toneGenerator = null;
+        if (toneGenerator != null) {
+            toneGenerator.release();
+            toneGenerator = null;
+        }
     }
 
     @Override
@@ -163,10 +160,18 @@ public abstract class AbstractLocationProvider implements LocationProvider {
      * @param name toneGenerator
      */
     protected void playDebugTone (int name) {
-        if (toneGenerator == null || !mConfig.isDebugging()) return;
+        if (!mConfig.isDebugging()) return;
 
-        int duration = 1000;
+        try {
+            if (toneGenerator == null) {
+                toneGenerator = new android.media.ToneGenerator(AudioManager.STREAM_NOTIFICATION, 100);
+            }
 
-        toneGenerator.startTone(name, duration);
+            int duration = 1000;
+
+            toneGenerator.startTone(name, duration);
+        } catch(RuntimeException e) {
+            logger.error("Failed to create android.media.ToneGenerator", e);
+        }
     }
 }

--- a/src/main/java/com/marianhello/bgloc/provider/ActivityRecognitionLocationProvider.java
+++ b/src/main/java/com/marianhello/bgloc/provider/ActivityRecognitionLocationProvider.java
@@ -46,8 +46,6 @@ public class ActivityRecognitionLocationProvider extends AbstractLocationProvide
 
     @Override
     public void onCreate() {
-        super.onCreate();
-
         Intent detectedActivitiesIntent = new Intent(DETECTED_ACTIVITY_UPDATE);
         detectedActivitiesPI = PendingIntent.getBroadcast(mContext, 9002, detectedActivitiesIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         registerReceiver(detectedActivitiesReceiver, new IntentFilter(DETECTED_ACTIVITY_UPDATE));

--- a/src/main/java/com/marianhello/bgloc/provider/RawLocationProvider.java
+++ b/src/main/java/com/marianhello/bgloc/provider/RawLocationProvider.java
@@ -25,8 +25,6 @@ public class RawLocationProvider extends AbstractLocationProvider implements Loc
 
     @Override
     public void onCreate() {
-        super.onCreate();
-
         locationManager = (LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
     }
 

--- a/src/main/java/com/tenforwardconsulting/bgloc/DistanceFilterLocationProvider.java
+++ b/src/main/java/com/tenforwardconsulting/bgloc/DistanceFilterLocationProvider.java
@@ -79,8 +79,6 @@ public class DistanceFilterLocationProvider extends AbstractLocationProvider imp
 
     @Override
     public void onCreate() {
-        super.onCreate();
-
         locationManager = (LocationManager) mContext.getSystemService(Context.LOCATION_SERVICE);
         alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
 


### PR DESCRIPTION
Proposed lazy initialization of android.media.ToneGenerator in com.marianhello.bgloc.provider.AbstractLocationProvider

Note: I'm unsure if making this PR against master is the right way to go. Please advise if this is not the proper procedure.

This will also avoid react-native-background-geolocation/issues/89 in release mode, as the ToneGenerator is only needed for debug. Late initialization will also re-try the acquisition of a track every time a playDebugSound is requested in debug mode, so even if there is a temporary failure, the app survives without a crash and have this event reported as an error.