### PR TITLE
Fix providers to be able to use same library in different apps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ android {
     defaultConfig {
         resValue "string", resourcePrefix + "account_name", 'Locations'
         resValue "string", resourcePrefix + "account_type", applicationId + '.mauron85.bgloc.account'
-        resValue "string", resourcePrefix + "content_authority", applicationId + '.mauron85.bgloc.provider'
+        resValue "string", resourcePrefix + "content_authority", applicationId + '.mauron85.bgloc.providers'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         minSdkVersion project.ext.getMinSdkVersion()
         versionCode 1


### PR DESCRIPTION
### Issue
Currently a device can not have two or more different apps using the [react-native-background-geolocation](https://github.com/mauron85/react-native-background-geolocation) library because there are conflicts in the providers.

There are previous issues that mention this problem:
https://github.com/mauron85/react-native-background-geolocation/issues/344

This PR addresses this issue