### PR TITLE
Crash resolve, delay was 60 seconds terminating task.

### DIFF
--- a/src/main/java/com/marianhello/bgloc/PostLocationTask.java
+++ b/src/main/java/com/marianhello/bgloc/PostLocationTask.java
@@ -91,7 +91,7 @@ public class PostLocationTask {
     }
 
     public void shutdown() {
-        shutdown(60);
+        shutdown(0);
     }
 
     public void shutdown(int waitSeconds) {


### PR DESCRIPTION
Crash resolve, delay was 60 seconds terminating task. so after next immediate launch it gets crashed. so i change it to 0 to terminate it immediately.