### PR TITLE
Fix Android10 hasMockLocationsEnabled(), AbstractLocationProvider.java

### DIFF
--- a/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
+++ b/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
@@ -15,6 +15,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.location.Location;
 import android.media.AudioManager;
+import android.os.Build;
 import android.provider.Settings;
 import android.widget.Toast;
 

--- a/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
+++ b/src/main/java/com/marianhello/bgloc/provider/AbstractLocationProvider.java
@@ -155,7 +155,8 @@ public abstract class AbstractLocationProvider implements LocationProvider {
     }
 
     public Boolean hasMockLocationsEnabled() {
-        return Settings.Secure.getString(mContext.getContentResolver(), android.provider.Settings.Secure.ALLOW_MOCK_LOCATION).equals("1");
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M &&
+          Settings.Secure.getString(mContext.getContentResolver(), android.provider.Settings.Secure.ALLOW_MOCK_LOCATION).equals("1");
     }
 
     /**


### PR DESCRIPTION
Check if device is 4, 5.  
In android 10 devices hasMockLocationsEnabled return true incorrectly. In emulators seems that always return 0.

The permission doesn't work anymore > Android6 then is better return false.