### PR TITLE
Remove deprecated option android.enableUnitTestBinaryResources

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-android.enableUnitTestBinaryResources=true
 android.builder.sdkDownload=true


### PR DESCRIPTION
## Issue
Got this error and failed to build project after upgrading Android Gradle plugin `4.0.0`
```
The option 'android.enableUnitTestBinaryResources' is deprecated.
The current default is 'false'.
It has been removed from the current version of the Android Gradle plugin.
The raw resource for unit test functionality is removed.
```