### PR TITLE
Update AndroidManifest.xml for android 10

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -44,7 +44,11 @@
             android:authorities="@string/mauron85_bgloc_content_authority"
             android:exported="false"
             android:syncable="true"/>
-        <service android:enabled="true" android:exported="false" android:name="com.marianhello.bgloc.service.LocationServiceImpl" />
+        <service 
+                 android:foregroundServiceType="location"
+                 android:enabled="true" 
+                 android:exported="false" 
+                 android:name="com.marianhello.bgloc.service.LocationServiceImpl" />
         <receiver android:enabled="true" android:exported="true" android:name="com.marianhello.bgloc.BootCompletedReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />


### PR DESCRIPTION
added the android:foregroundServiceType value for the foreground location service, to fully support android 10 based on android docs https://developer.android.com/training/location/permissions#foreground