### PR TITLE
Notifications cleanup

### DIFF
--- a/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
+++ b/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
@@ -92,7 +92,9 @@ public class NotificationHelper {
             // the NotificationChannel class is new and not in the support library
             android.app.NotificationManager notificationManager = (android.app.NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             notificationManager.createNotificationChannel(createServiceChannel(appName));
-            notificationManager.createNotificationChannel(createSyncChannel());
+            // comment out this line as the main app is not using sync service
+            // TODO: consider dynamically register this notification channel based on config
+            // notificationManager.createNotificationChannel(createSyncChannel());
             notificationManager.createNotificationChannel(createAndroidPermissionsChannel(appName));
         }
     }

--- a/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
+++ b/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
@@ -85,27 +85,29 @@ public class NotificationHelper {
         }
     }
 
-    public static void registerAllChannels(Context context) {
+   public static void registerAllChannels(Context context) {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            String appName = ResourceResolver.newInstance(context).getString(("app_name"));
-            // Create the NotificationChannel, but only on API 26+ because
-            // the NotificationChannel class is new and not in the support library
+            String backgroundServiceChannelName = ResourceResolver.newInstance(context).getString(("background_service_notification_channel_name"));
             android.app.NotificationManager notificationManager = (android.app.NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            notificationManager.createNotificationChannel(createServiceChannel(appName));
+            notificationManager.createNotificationChannel(createServiceChannel(backgroundServiceChannelName));
             // comment out this line as the main app is not using sync service
             // TODO: consider dynamically register this notification channel based on config
             // notificationManager.createNotificationChannel(createSyncChannel());
-            notificationManager.createNotificationChannel(createAndroidPermissionsChannel(appName));
+
+            String permissionChannelName = ResourceResolver.newInstance(context).getString(("android_permission_notification_channel_name"));
+            notificationManager.createNotificationChannel(createAndroidPermissionsChannel(permissionChannelName));
         }
     }
 
     public static void registerServiceChannel(Context context) {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            String appName = ResourceResolver.newInstance(context).getString(("app_name"));
-            // Create the NotificationChannel, but only on API 26+ because
-            // the NotificationChannel class is new and not in the support library
+            String backgroundServiceChannelName = ResourceResolver.newInstance(context).getString(("background_service_notification_channel_name"));
             android.app.NotificationManager notificationManager = (android.app.NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            notificationManager.createNotificationChannel(createServiceChannel(appName));
+            notificationManager.createNotificationChannel(createServiceChannel(backgroundServiceChannelName));
         }
     }
 

--- a/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
+++ b/src/main/java/com/marianhello/bgloc/sync/NotificationHelper.java
@@ -124,6 +124,7 @@ public class NotificationHelper {
     public static NotificationChannel createServiceChannel(CharSequence name) {
         NotificationChannel channel = new NotificationChannel(SERVICE_CHANNEL_ID, name, android.app.NotificationManager.IMPORTANCE_LOW);
         channel.enableVibration(false);
+        channel.setShowBadge(false); // avoid badge count due to background service notification
         return channel;
     }
 

--- a/src/main/java/com/marianhello/bgloc/sync/SyncAdapter.java
+++ b/src/main/java/com/marianhello/bgloc/sync/SyncAdapter.java
@@ -73,7 +73,9 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements HttpPost
         batchManager = new BatchManager(this.getContext());
         notificationManager = (NotificationManager) getContext().getSystemService(Context.NOTIFICATION_SERVICE);
 
-        NotificationHelper.registerSyncChannel(context);
+        // comment out this line as the main app is not using sync service
+        // TODO: consider dynamically register this notification channel based on config
+        // NotificationHelper.registerSyncChannel(context);
     }
 
     /*

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">app_name</string>
+    <string name="background_service_notification_channel_name">Background location service</string>
+    <string name="android_permission_notification_channel_name">Permission notifications</string>
 </resources>


### PR DESCRIPTION
Part of the solution proposed in this issue https://github.com/Path-Check/covid-safe-paths/issues/1276

- Comment out notification channel registration for sync service.
- Updated the notification channel names for permission and background service.
- The updated names should be coming from the `covid-safe-paths` project, however, we also added the fallback names in this package just in case. These names are generic and not project specific.