### PR TITLE
enableUnitTestBinaryResources deprecated

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-android.enableUnitTestBinaryResources=true
+android.enableUnitTestBinaryResources=false
 android.builder.sdkDownload=true


### PR DESCRIPTION
on react native 0.63 this would not work, it is required to disable this option as it is deprecated. I use sdkversion 28