### PR TITLE
Fix ANDROID SDK 29 require ACCESS_BACKGROUND_LOCATION permission

### DIFF
--- a/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
+++ b/src/main/java/com/marianhello/bgloc/BackgroundGeolocationFacade.java
@@ -52,10 +52,7 @@ public class BackgroundGeolocationFacade {
     public static final int AUTHORIZATION_AUTHORIZED = 1;
     public static final int AUTHORIZATION_DENIED = 0;
 
-    public static final String[] PERMISSIONS = {
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-            Manifest.permission.ACCESS_FINE_LOCATION
-    };
+    public static final String[] PERMISSIONS = getRequiredPermissions();
 
     private boolean mServiceBroadcastReceiverRegistered = false;
     private boolean mLocationModeChangeReceiverRegistered = false;
@@ -69,6 +66,22 @@ public class BackgroundGeolocationFacade {
     private BackgroundLocation mStationaryLocation;
 
     private org.slf4j.Logger logger;
+
+    private static String[] getRequiredPermissions() {
+        if(android.os.Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+            return new String[]{
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                    Manifest.permission.ACCESS_FINE_LOCATION
+            };
+        }
+        else {
+            return new String[]{
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+            };
+        }
+    }
 
     public BackgroundGeolocationFacade(Context context, PluginDelegate delegate) {
         mContext = context;


### PR DESCRIPTION
To access location in the background in SDK 29, the app requires ACCESS_BACKGROUND_LOCATION permission

[source](https://developer.android.com/about/versions/10/privacy/changes#app-access-device-location)

---

Not sure how to create a PR across submodules. This PR only includes the code change. The `plugin.xml` also requires the following change (to add the permission to AndroidManifest)

```
            <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
```
