### PR TITLE
FIX: Removed option android.enableUnitTestBinaryResources as it's dep…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-android.enableUnitTestBinaryResources=true
+# android.enableUnitTestBinaryResources=true
 android.builder.sdkDownload=true

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@mauron85/background-geolocation-android",
+  "version": "1.0.0",
+  "description": "Background Geolocation for Android",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/@mauron85/background-geolocation-android.git"
+  },
+  "author": "Marian Hello",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/@mauron85/background-geolocation-android/issues"
+  },
+  "homepage": "https://github.com/@mauron85/background-geolocation-android#readme"
+}


### PR DESCRIPTION
### Problem

After upgrading Gradle plugin from 3.6.3 to 4.1.0 I got this error below:

```
A problem occurred evaluating project ':@mauron85_react-native-background-geolocation-common'.
> Failed to apply plugin 'com.android.internal.library'.
   > The option 'android.enableUnitTestBinaryResources' is deprecated.
     The current default is 'false'.
     It has been removed from the current version of the Android Gradle plugin.
     The raw resource for unit test functionality is removed.
```
     
Look like the code below is not needed in "gradle.properties" file. After removing it the error is gone 

`android.enableUnitTestBinaryResources=true`

