### PR TITLE
set android.enableUnitTestBinaryResources to false

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-android.enableUnitTestBinaryResources=true
+android.enableUnitTestBinaryResources=false
 android.builder.sdkDownload=true


### PR DESCRIPTION
Fixed build error: 
> Failed to apply plugin 'com.android.internal.library'.
   > The option 'android.enableUnitTestBinaryResources' is deprecated.
     The current default is 'false'.
     It has been removed from the current version of the Android Gradle plugin.
     The raw resource for unit test functionality is removed.