### PR TITLE
fix build error - 'android.enableUnitTestBinaryResources' is deprecated.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-android.enableUnitTestBinaryResources=true
+android.enableUnitTestBinaryResources=false
 android.builder.sdkDownload=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-android.enableUnitTestBinaryResources=false
 android.builder.sdkDownload=true


### PR DESCRIPTION
```
The option 'android.enableUnitTestBinaryResources' is deprecated.
The current default is 'false'.
It has been removed from the current version of the Android Gradle plugin.
The raw resource for unit test functionality is removed.
```